### PR TITLE
Adding search functionality for contacts.

### DIFF
--- a/cloud/SearchContactIndex.js
+++ b/cloud/SearchContactIndex.js
@@ -1,0 +1,50 @@
+/**
+  To make search efficient, we keep SearchContactIndex objects, which are mappings
+  from strings to Contact IDs.
+*/
+class SearchContactIndex extends Parse.Object {
+  constructor(text, contactId, fullName) {
+    super('SearchContactIndex');
+
+    this.set('text', text);
+    this.set('contactId', contactId);
+    this.set('fullName', fullName);
+  }
+
+  static createIndexesForContact(anchorContact) {
+    // Only make indexes for Contacts with names.
+    var name = anchorContact.get('fullName');
+    if (name.length > 0) {
+      var staging = [name];
+
+      var emails = anchorContact.get('emails');
+      if (emails) {
+        for (var email of emails) {
+          staging.push(email);
+        }
+      }
+
+      var pieces = [];
+      for (var s of staging) {
+        let fixed = s.replace('-', ' ').replace('@', ' ').replace('.', ' ');
+        pieces = pieces.concat(fixed.split(' '));
+      }
+
+      for (var p of pieces) {
+        let fixed = p.toLowerCase();
+        var index = new SearchContactIndex(fixed, anchorContact.id, name);
+        index.setACL(anchorContact.getACL());
+        index.save(null, {
+          success: function() {
+            console.log("Saved contact index '" + fixed + "' -> " + anchorContact.id);
+          },
+          error: function(e) {
+            console.error("Error saving contact index '" + fixed + "' -> " + anchorContact.id + ": " + e);
+          }
+        });
+      }
+    }
+  }
+}
+
+module.exports = SearchContactIndex;

--- a/cloud/main.js
+++ b/cloud/main.js
@@ -51,3 +51,10 @@ Parse.Cloud.define('sync', function (req, res) {
     res.error(e);
   });
 });
+
+Parse.Cloud.afterSave("Contact", function(request) {
+  var anchorContact = request.object;
+
+  // After saving, update the index we use to search for contacts.
+  SearchContactIndex.createIndexesForContact(anchorContact);
+});


### PR DESCRIPTION
This is pretty basic, it only supports matching the beginning of keywords
within contacts. It does include searching name and emails, but no other
metadata.

It works by creating index models every time Contacts are saved, mostly
so that we can utilize Parse's built-in text indexes.